### PR TITLE
fix: remove local stored access token if expired

### DIFF
--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -17,6 +17,7 @@ export const getActivities = ({
     .then((res) => res.json())
     .then((data) => {
       if (data.message === 'Authorization Error') {
+        localStorage.removeItem('accessToken');
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         getAccessToken({ setLoading, setActivities });
       } else {


### PR DESCRIPTION
- removed any stored access token if you had visited site previously and now the token has expired