### PR TITLE
Fix - trim whitespace on blog titles

### DIFF
--- a/src/pages/Admin/Blog/CreateBlog/CreateBlog.tsx
+++ b/src/pages/Admin/Blog/CreateBlog/CreateBlog.tsx
@@ -24,7 +24,7 @@ function CreateBlog() {
         headerText="Add a new blog post below"
         onSubmit={(e) => {
           e.preventDefault();
-          saveBlog(title, body, navigate, 'blog created');
+          saveBlog(title.trim(), body, navigate, 'blog created');
         }}
         buttonType={ButtonTypes.submit}
         buttonText="Create blog"

--- a/src/pages/Admin/Blog/EditBlog/EditBlog.tsx
+++ b/src/pages/Admin/Blog/EditBlog/EditBlog.tsx
@@ -48,8 +48,8 @@ function EditBlog() {
         onSubmit={(e) => {
           e.preventDefault();
           if (title) {
-            if (originalTitle === title) {
-              saveBlog(title, body || '', navigate, 'blog updated');
+            if (originalTitle.trim() === title.trim()) {
+              saveBlog(title.trim(), body || '', navigate, 'blog updated');
             } else {
               editBlog(title, body || '', navigate, originalTitle);
             }

--- a/src/pages/Admin/Blog/EditBlog/EditBlog.tsx
+++ b/src/pages/Admin/Blog/EditBlog/EditBlog.tsx
@@ -74,7 +74,7 @@ function EditBlog() {
             value={title || ''}
             defaultValue={title}
             onChange={(e) => {
-              if (titles.includes(e.target.value.toLowerCase()) && originalTitle !== e.target.value) {
+              if (titles.includes(e.target.value.toLowerCase().trim()) && originalTitle !== e.target.value.trim()) {
                 setValidation(true);
               } else {
                 setValidation(false);

--- a/src/pages/Blog/Blog.utils.ts
+++ b/src/pages/Blog/Blog.utils.ts
@@ -27,7 +27,7 @@ export const getBlogTitles = (setTitles: (titles: string[]) => void) => {
 
 export const editBlog = (title: string, body: string, navigate: NavigateFunction, originalTitle: string) => {
   const newTitle = originalTitle.toLowerCase().replaceAll(' ', '-');
-  saveBlog(title, body, navigate, 'blog edited');
+  saveBlog(title.trim(), body, navigate, 'blog edited');
   deleteDoc(doc(db, 'blog', newTitle));
 };
 


### PR DESCRIPTION
- add trim to get rid of trailing whitespace breaking the create & edit blog